### PR TITLE
Pr 0202

### DIFF
--- a/app/controllers/chip_results_controller.rb
+++ b/app/controllers/chip_results_controller.rb
@@ -20,7 +20,8 @@ class ChipResultsController < ApplicationController
       redirect_to(root_path, alert: FlashMessages::CHIP_EDIT_DENIED) && return unless @match_group.rule.is_chip
     end
 
-    @players = @match_group.players
+    player_ids = @match_group.chip_results.pluck(:player_id)
+    @players = Player.find(player_ids)
     mg_chip_results = @match_group.chip_results.select(:match_group_id, :player_id, :number)
     chip_results_ary = mg_chip_results.map do |cr|
       cr.attributes.delete('id') # idは除いてハッシュ化

--- a/app/controllers/chip_results_controller.rb
+++ b/app/controllers/chip_results_controller.rb
@@ -2,7 +2,8 @@
 
 class ChipResultsController < ApplicationController
   before_action :authenticate_user!, only: [:update]
-  before_action :set_match_group, :set_rule, only: %i[edit update]
+  before_action :set_match_group, only: %i[edit update]
+  before_action :set_rule, only: %i[update]
 
   def edit
     if params[:tk] && params[:resource_type]

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -27,8 +27,7 @@ class LeaguesController < ApplicationController
                     alert: FlashMessages::ACCESS_DENIED) && return
       end
     end
-
-    @l_matches = Match.includes(:results).where(league_id: params[:id])
+    @l_matches = Match.includes(:results).where(league_id: params[:id]).asc
     @graph_datasets, @y_max, @y_min = @league.graph_data # 成績推移グラフのデータ
     @graph_labels =  @league.graph_label # 成績推移グラフの日付ラベル
     @rank_table_data = @league.rank_table # 順位表のデータ

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -180,7 +180,7 @@ class MatchesController < ApplicationController
 
   def set_player_league
     player_ids = @match.results.pluck(:player_id)
-    @players = Player.where(id: player_ids)
+    @players = Player.find(player_ids)
     @league = League.find_by(id: @match.league_id)
   end
 

--- a/app/javascript/match_form.js
+++ b/app/javascript/match_form.js
@@ -222,6 +222,14 @@ $(document).on('turbolinks:load', function () {
       $('#match_rule_id').css('pointer-events', 'none');
       $('#match_rule_id').attr('tabindex', '-1');
     }
+    $('#match_create_btn').on('click', function(e) {
+      var remainingScore = $('.js-remaining_score_value').text();
+      if (parseInt(remainingScore) !== 0) {
+        if (!window.confirm('残得点が0ではありません。登録しますか？')) {
+          return false;
+        }
+      }
+    });
   }
   // league作成・編集ページのとき実行
   if (/^\/leagues\/[^/]+\/edit$/.test(window.location.pathname) || window.location.pathname === '/leagues/new') {
@@ -248,11 +256,11 @@ $(document).on('turbolinks:load', function () {
   checkFormCompletion();
   updateRemainingScore();
   // フィールドの変更時にチェック関数を実行
-  $('[id$="_ie"], [id$="_score"], [id$="_point"]').change(checkFormCompletion);
+  $('[id$="_ie"], [id$="_score"], [id$="_point"]').on('change', checkFormCompletion);
   // 得点に変化があったとき、残得点の更新
-  $('[id$="_score"]').change(updateRemainingScore);
+  $('[id$="_score"]').on('input', updateRemainingScore);
   // 得点・ルール・家に変化があったとき、ポイント・順位を計算して表示
-  $('[id$="_score"], #match_rule_id, [id$="_ie"]').change(calculate_point_rank);
+  $('[id$="_score"], #match_rule_id, [id$="_ie"]').on('input', calculate_point_rank);
 });
 
 // ルール詳細情報の表示・非表示

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,6 +24,7 @@ require("slide.js")
 require("player_results.js")
 require("show_modal.js")
 require("clipboard.js")
+require("tip_form.js")
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/tip_form.js
+++ b/app/javascript/tip_form.js
@@ -1,0 +1,35 @@
+// ● チップの合計枚数を計算し、注意メッセージを表示する
+function calcTotalTip() {
+  let tipNum = [];
+  $('[id*="tip_number_"]').each(function() {
+    tipNum.push($(this).val());
+  });
+
+  let tipTotalNum = tipNum.filter(v => v).reduce(function(sum, element){
+    return sum + parseInt(element, 10);
+  }, 0);
+
+  if (tipTotalNum === 0) {
+    $('#tip_total_warning').css('visibility', 'hidden');
+  } else {
+    $('#tip_total_warning').css('visibility', 'visible');
+  }
+  return tipTotalNum;
+}
+
+
+$(document).on('turbolinks:load', function () {
+  // ページ読み込み時にチップ合計枚数を計算
+  calcTotalTip();
+  // チップ枚数入力時にチップ合計枚数を計算
+  $('[id*="tip_number_"]').on('input', calcTotalTip);
+  // チップ登録ボタンクリック時にチップ合計枚数がゼロでない場合、確認メッセージ出力
+  $('#tip_create_btn').on('click', function() {
+    let totalTip = calcTotalTip()
+    if (totalTip !== 0) {
+      if (!window.confirm('チップ合計枚数が0ではありません。登録しますか？')) {
+        return false;
+      }
+    }
+  });
+});

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -24,14 +24,14 @@ class League < ApplicationRecord
   def first_record_day
     return nil if matches.count.zero?
 
-    @first_record_day ||= matches.first.match_on.to_s(:yeardate)
+    @first_record_day ||= matches.min_by(&:match_on).match_on.to_s(:yeardate)
   end
 
   # リーグにおける最後に記録した日
   def last_record_day
     return nil if matches.count.zero?
 
-    @last_record_day ||= matches.last.match_on.to_s(:yeardate)
+    @last_record_day ||= matches.max_by(&:match_on).match_on.to_s(:yeardate)
   end
 
   # リーグにおける総対戦数

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -13,7 +13,7 @@ class Match < ApplicationRecord
   validates :memo, length: { maximum: 50 }
 
   scope :desc, -> { order(match_on: :desc, created_at: :desc) } # 対局日付の降順
-  scope :asc, -> { order(match_on: :asc, created_at: :desc) } # 対局日付の降順
+  scope :asc, -> { order(match_on: :asc, created_at: :asc) } # 対局日付の降順
   scope :match_ids, lambda { |match_ids, play_type|
                       where(id: match_ids).where(play_type: play_type)
                     } # play_typeに応じたmatch_idを配列で格納

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -20,10 +20,12 @@ class Player < ApplicationRecord
   SANMA = 3
   RANK_DATA_NUM = 10 # 順位グラフに表示する数
 
-  # resultsからプレイヤーを取得する
+  # resultsからプレイヤー名を取得する
   def self.find_by_results(results)
     player_ids = results.map(&:player_id)
-    Player.where(id: player_ids).includes(:results)
+    player_ids.map do |p_id|
+      Player.find(p_id).name
+    end
   end
 
   # ************************************

--- a/app/views/chip_results/_form.html.haml
+++ b/app/views/chip_results/_form.html.haml
@@ -4,7 +4,9 @@
       - if @match_group.created_by?(current_player)
         .info-content.text-center
           %i.bx.bxs-info-circle.pe-1.text-pink{style: "padding-top: 1px;"}
-          %span.mb-0.fw-bold 増減したチップ枚数を入力してください(#{@rule.chip_rate}pt / 枚)
+          %span.mb-0.fw-bold 増減したチップ枚数を入力してください
+        .info-content.text-center
+          %span.mb-0 (例) 20枚スタートで15枚で終えた場合: -5枚で入力する
 
     = form_with model: @form, url: match_group_chip_results_path ,method: :patch, local: true do |form|
       = render 'layouts/validation_error', instance: @form
@@ -15,20 +17,25 @@
           %p.col-6.fw-bold.text-main.text-center.mb-0.mx-1
             = @players[i]["name"]
           .d-flex.align-items-end.col-4
-            = f.number_field :number, autofocus: true,
+            = f.number_field :number, id: "tip_number_#{i}", autofocus: true,
               class: 'form-control py-md-1 rounded bg-white'
             %span.text-main.mb-0.mx-1.mx-md-2 枚
           = f.hidden_field :match_group_id, value: @match_group.id
           = f.hidden_field :player_id, value: @players[i]["id"]
           = f.hidden_field :is_temporary, value: false
           - i += 1
-      .col-8.col-md-5.m-auto.my-3
-        - if @match_group.created_by?(current_player)
-          = form.button type: 'submit', class: 'main-btn--orange w-100' do
+      - if @match_group.created_by?(current_player)
+        .col-8.col-md-5.m-auto.mt-3
+          = form.button type: 'submit', id: "tip_create_btn", class: 'main-btn--orange w-100' do
             .btn-text
               %i.fa-solid.fa-pen.pe-1.fw-bold
               %span #{action}
-        - else
+        .col-10.m-auto.mt-1
+          #tip_total_warning.d-flex.justify-content-center.align-items-center
+            %i.fa-solid.fa-triangle-exclamation.text-warning.fs-sm.pe-1
+            %p.fs-sm.text-main.fw-bold.mb-0 合計枚数が0ではありません
+      - else
+        .col-8.col-md-5.m-auto.my-3
           = link_to match_group_path(@match_group), class: "main-btn--white-orange mb-3",
             data: { "turbolinks" => false } do
             .btn-text

--- a/app/views/chip_results/edit.html.haml
+++ b/app/views/chip_results/edit.html.haml
@@ -1,4 +1,4 @@
-.container
+.container.mb-5
   .row.justify-content-center
     .col-11.col-md-9.text-center.pb-2
       .page-title

--- a/app/views/match_groups/_result_table.html.haml
+++ b/app/views/match_groups/_result_table.html.haml
@@ -104,13 +104,17 @@
   .row
     .col-9.col-md-5.col-lg-4.m-auto.mt-2.mb-1
       - if @match_group.rule.is_chip
-        = link_to edit_match_group_chip_results_path(session[:mg]), class: "main-btn--white-orange mb-1" do
+        = link_to edit_match_group_chip_results_path(session[:mg]),
+          data: { confirm: "チップ集計しますか？(この成績表に対局成績を追加できなくなります)"},
+          class: "main-btn--white-orange mb-1" do
           .btn-text
             %i.fa-regular.fa-circle-check.pe-1
             %span チップ集計する
 
       - else
-        = link_to match_group_path(session[:mg], fix: true), class: "main-btn--white-orange mb-1" do
+        = link_to match_group_path(session[:mg], fix: true),
+          data: { confirm: "記録終了しますか？（この成績表に対局成績を追加できなくなります）"},
+          class: "main-btn--white-orange mb-1" do
           .btn-text
             %i.fa-regular.fa-circle-check.pe-1
             %span 記録終了する

--- a/app/views/match_groups/_result_table.html.haml
+++ b/app/views/match_groups/_result_table.html.haml
@@ -1,18 +1,18 @@
-// 今回の対局成績表
-- if request.path == match_group_path(@match_group)
+- if request.path != root_path
   .row.justify-content-center.mt-4
-    .col-12.col-md-10.text-center
+    .col-12.col-md-9.text-center.px-0
       .d-flex.justify-content-between.align-items-end.border-green-bottom-title_main.text-main
         .left-content.d-flex.align-items-end
           %h4.text-center.text-md-start.text-nowrap.fw-bold.mb-0
             成績表
-        .right-content
-          - if @match_group.created_by?(current_player)
-            = link_to match_group_path(@match_group),
-                data: { confirm: "対局成績表を削除しますか？" },
-                method: :delete,
-                class: 'px-1 pb-0 text-main' do
-              %i.fa-regular.fa-trash-can.me-2
+        - if request.path == match_group_path(@match_group)
+          .right-content
+            - if @match_group.created_by?(current_player)
+              = link_to match_group_path(@match_group),
+                  data: { confirm: "対局成績表を削除しますか？" },
+                  method: :delete,
+                  class: 'px-1 pb-0 text-main' do
+                %i.fa-regular.fa-trash-can.me-2
 
 .row.justify-content-center
   .col-12.col-md-9.m-auto

--- a/app/views/match_groups/_result_table.html.haml
+++ b/app/views/match_groups/_result_table.html.haml
@@ -31,8 +31,8 @@
         %thead
           %tr.w-100.fw-bold
             %th.w-no{scope: "col"} No
-            - Player.find_by_results(@match_group.matches.first.results).each do |p|
-              %th.w-name{scope: "col"}= p.name
+            - Player.find_by_results(@match_group.matches.first.results).each do |p_name|
+              %th.w-name{scope: "col"}= p_name
             - if @match_group.created_by?(current_player)
               %th.w-edit{scope: "col"}
               %th.w-delete{scope: "col"}

--- a/app/views/match_groups/show.html.haml
+++ b/app/views/match_groups/show.html.haml
@@ -3,14 +3,21 @@
   .row
     .col-9.col-md-5.col-lg-4.m-auto.mt-2.text-center
       - if user_signed_in?
-        = link_to root_path,
-          class: "main-btn--orange w-100 mb-3" ,data: { "turbolinks" => false } do
-          .btn-text
-            %i.fa-solid.fa-house.pe-1.fw-bold
-            %span HOME
-        = render partial: 'layouts/share_link'
+        - if @share_token.present?
+          = link_to url_for(request.path_parameters.merge(tk: @share_token.token, resource_type: @share_token.resource_type)),
+            class: "main-btn--white-lightgray mb-3", id: "update_btn" do
+            %i.bx.bx-revision.pe-1.text-lightgray.fw-bold{style: "padding-top: 1px;"}
+            更新
+          = render partial: 'layouts/share_link'
+        - else
+          = link_to root_path,
+            class: "main-btn--orange w-100 mb-3" ,data: { "turbolinks" => false } do
+            .btn-text
+              %i.fa-solid.fa-house.pe-1.fw-bold
+              %span HOME
       - else
-        = link_to url_for(request.path_parameters.merge(tk: @share_token.token, resource_type: @share_token.resource_type)),
-          class: "main-btn--white-lightgray", id: "update_btn" do
-          %i.bx.bx-revision.pe-1.text-lightgray.fw-bold{style: "padding-top: 1px;"}
-          更新
+        - if @share_token.present?
+          = link_to url_for(request.path_parameters.merge(tk: @share_token.token, resource_type: @share_token.resource_type)),
+            class: "main-btn--white-lightgray mb-3", id: "update_btn" do
+            %i.bx.bx-revision.pe-1.text-lightgray.fw-bold{style: "padding-top: 1px;"}
+            更新

--- a/app/views/matches/show.html.haml
+++ b/app/views/matches/show.html.haml
@@ -56,7 +56,8 @@
             .btn-text
               %i.fa-solid.fa-angles-right
               %span #{@match_group.matches.count + 1}戦目の成績を登録
-    = render partial: 'match_groups/result_table'
+    .row
+      = render partial: 'match_groups/result_table'
     .row
       .col-8.col-md-4.col-lg-4.text-center.m-auto.mb-2
         = render partial: 'layouts/share_link'

--- a/app/views/tops/show.html.haml
+++ b/app/views/tops/show.html.haml
@@ -8,10 +8,16 @@
             .d-flex.align-items-center.justify-content-center
               %i.bx.bxs-info-circle.pe-2.text-pink
               %p.mb-0.fw-bold.text-main 記録を続けるか終了してください
-          = link_to new_match_path, class: "main-btn--white-green mb-3" do
-            .btn-text
-              %i.fa-solid.fa-angles-right
-              %span 次の対局を記録する
+          - if session[:league].present?
+            = link_to new_match_path(league: session[:league]), class: "main-btn--white-green mb-3" do
+              .btn-text
+                %i.fa-solid.fa-angles-right
+                %span 次の対局を記録する
+          - else
+            = link_to new_match_path, class: "main-btn--white-green mb-3" do
+              .btn-text
+                %i.fa-solid.fa-angles-right
+                %span 次の対局を記録する
     - else
       .row
         .info.py-2.mb-1.text-center.fadeIn

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,8 @@ module MahjongScoreManagement
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     # config.autoload_paths += Dir.glob("#{config.root}/app/controllers/players/rules_controller.rb")
-    
-    config.i18n.default_locale = :ja 
+
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
## 動作確認

<!-- PCで動かした場合の動作確認を動画で貼る or 見た目のみの作成で機能が必要ない場合は画像でOK -->
**PCの動作確認動画**

## やったこと
<!-- 実装した内容を書く-->
- **pr_0202**
    - 【match登録】pt計算のイベントをinputに変更し、入力した値に応じて即時計算されるよう修正
    - 【match登録】成績登録時と成績表のプレイヤー順が異なるバグを修正
    - 【tip登録】合計枚数が0でないときに確認メッセージ出力するよう変更
    - 【match_group】記録終了/チップ集計をクリックした際、確認メッセージを出力するよう修正
    - 【成績表】match詳細画面かつ記録中の場合、成績表の見出しを表示するよう修正
    - 【match登録】リーグ戦記録にて、1戦目登録後トップページに戻ってから「次の対局を記録」ボタンから対局登録するとmatchがleagueと紐づかない問題修正
    - 【league詳細】リーグ一覧がcreate_at順に並べていない問題修正
    - 【共有リンク】共有リンク開いている場合はログイン中でも更新ボタン表示する

## 実装のリンク
<!-- ガントチャートのタスク対象のセルのリンクを貼る -->

## 備考

<!-- なければ、書かなくても良い。相談事項があれば、ここに書く。-->