### PR TITLE
Pr 0211

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -67,6 +67,7 @@ class MatchesController < ApplicationController
       redirect_to match_path(@match), notice: FlashMessages::CREATE_MATCH
     else
       @players = session[:players]
+      score_in_hundred
       render :new
     end
   end
@@ -87,6 +88,7 @@ class MatchesController < ApplicationController
     else
       set_player_league
       gon_setter('update')
+      score_in_hundred
       render :edit
     end
   end

--- a/app/javascript/match_form.js
+++ b/app/javascript/match_form.js
@@ -1,5 +1,5 @@
-$(document).on('turbolinks:load', function () { 
-  
+$(document).on('turbolinks:load', function () {
+
   //*******************************************
   //*. 関数の定義　                           *
   //*******************************************
@@ -26,15 +26,14 @@ $(document).on('turbolinks:load', function () {
     }
 
     if (calculatedRemainingScore === 0) {
-      $('#match_create_warning').css('visibility', 'hidden');
+      $('#match_create_warning_1').css('visibility', 'hidden');
     } else {
-      $('#match_create_warning').css('visibility', 'visible');
+      $('#match_create_warning_1').css('visibility', 'visible');
     }
   }
 
   // ● ルール選択肢で選択された時のjs
   function selectRule(selecter) {
-
     let id = $(selecter).val();
     $.ajax({
       type: 'GET', // リクエストのタイプ
@@ -100,14 +99,14 @@ $(document).on('turbolinks:load', function () {
     })
   }
 
-  // ● 家・得点・ptがすべて埋まっていたらボタン状態更新
+  // ● 対局日・家・得点・ptがすべて入力済みかつ家重複状態に応じてボタン状態更新
   function checkFormCompletion() {
     let isComplete = true;
 
-    // IE, Score, Point フィールドのチェック
-    $('[id$="_ie"], [id$="_score"], [id$="_point"]').each(function() {
+    // match_on, IE, Score, Pointフィールドのチェックと家重複チェック
+    $('[id$="_match_on"], [id$="_ie"], [id$="_score"], [id$="_point"]').each(function() {
       let value = $(this).val();
-      if (value === "" || isNaN(value)) {
+      if (value === "" || value === null || value === undefined || checkDuplicateIE()) {
         isComplete = false;
         return false; // ループを中断
       }
@@ -119,6 +118,23 @@ $(document).on('turbolinks:load', function () {
     } else {
       $('#match_create_btn').prop('disabled', true).addClass('inactive');
     }
+    if (checkDuplicateIE()) {
+      $('#match_create_warning_2').css('visibility', 'visible');
+    } else {
+      $('#match_create_warning_2').css('visibility', 'hidden');
+    }
+  }
+
+  // ● 家の重複チェック
+  function checkDuplicateIE() {
+    let ies = [];
+    $('[id$="_ie"]').each(function() {
+      ies.push($(this).val());
+    });
+    let isDuplicate = ies.some(function(ie, index) {
+      return ies.indexOf(ie) !== index;
+    });
+    return isDuplicate;
   }
 
   // ● 得点項目の入力が残り１つの場合、点数を自動補完する
@@ -219,10 +235,10 @@ $(document).on('turbolinks:load', function () {
   }
 
   // *********************************************************************
-  // match作成・編集ページのとき、ルール検索実行
-  if (/^\/matches\/[^/]+\/edit$/.test(window.location.pathname) || window.location.pathname === '/matches/new') {
+  // match関連ページのとき、ルール検索実行
+  if (/\/matches(\/|$)/.test(window.location.pathname)) {
     let selecter = '#match_rule_id';
-    $(document).ready(selectRule(selecter));
+    selectRule(selecter);
     $(selecter).change(function () {
       selectRule(selecter);
     });
@@ -270,7 +286,7 @@ $(document).on('turbolinks:load', function () {
   checkFormCompletion();
   updateRemainingScore();
   // フィールドの変更時にチェック関数を実行
-  $('[id$="_ie"], [id$="_score"], [id$="_point"]').on('change', checkFormCompletion);
+  $('[id$="_match_on"], [id$="_ie"], [id$="_score"], [id$="_point"]').on('change', checkFormCompletion);
   // 得点に変化があったとき、残得点の更新
   $('[id$="_score"]').on('input', updateRemainingScore);
   // 得点の未入力が残り１つの場合、点数を自動補完する

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -24,6 +24,6 @@ class Match < ApplicationRecord
 
   # ログインユーザーの該当対局のポイントを取得する
   def current_player_point(p_id)
-    results.find_by(player_id: p_id).point
+    results.find_by(player_id: p_id)&.point
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -7,7 +7,7 @@ class Match < ApplicationRecord
   has_many :results, dependent: :destroy # matchに紐づいたresultsも削除される
   accepts_nested_attributes_for :results # resultも同時に保存できるようになる
 
-  validates :play_type, presence: true, numericality: { in: 3..4 }
+  validates :play_type, presence: true, inclusion: { in: [3, 4] }
   validates :match_on, presence: true
   validates :rule_id, presence: true
   validates :memo, length: { maximum: 50 }

--- a/app/models/match_group.rb
+++ b/app/models/match_group.rb
@@ -11,11 +11,6 @@ class MatchGroup < ApplicationRecord
 
   CHIP = 'tip'
 
-  # match_groupに属する対局が何人麻雀か取得する
-  def play_type
-    matches.first.play_type
-  end
-
   # match_group_id単位にすべてのmatchの各プレイヤーのptを配列で取得する
   def table_element
     match_results = []
@@ -50,19 +45,9 @@ class MatchGroup < ApplicationRecord
     matches.first.player_id == current_player.id
   end
 
-  # match_groupに紐づくmatchの数を返す
-  def match_count
-    matches.count
-  end
-
-  # チップ有ルールかどうか
-  def chip_rule?
-    Rule.find_by(id: rule_id).is_chip?
-  end
-
   # 成績表においてチップレコードかどうか
   def chip_record?(idx)
-    chip_rule? && matches.count < idx + 1
+    tip_rule? && matches.count < idx + 1
   end
 
   # match_groupに紐づく最後のmatchの日付を取得
@@ -71,6 +56,10 @@ class MatchGroup < ApplicationRecord
   end
 
   private
+  # チップ有ルールかどうか
+  def tip_rule?
+    Rule.find_by(id: rule_id).is_chip?
+  end
 
   # チップデータはユーザーによって登録されたデータか(=仮データでないか)
   def not_temporary_data?

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -225,22 +225,10 @@ class Player < ApplicationRecord
   # ************************************
   # ユーザー招待リンク用
   # ************************************
-
-  # current_playerから該当プレイヤーが招待可能か真偽値を返す
-  def can_invite?(current_player)
-    self.cp = current_player
-    recorded_by_current_player? && user_id.nil?
-  end
-
   # 招待トークンを発行してDB保存する
   def create_invite_token
     self.invite_token = SecureRandom.urlsafe_base64
     update_columns(invite_token: invite_token, invite_create_at: Time.zone.now)
-  end
-
-  # current_playerが記録をつけたプレイヤーか真偽値を返す
-  def recorded_by_current_player?
-    recorded_players.include?(id)
   end
 
   # current_playerが招待可能な全プレイヤーを取得する

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -4,7 +4,7 @@ class Rule < ApplicationRecord
   belongs_to :player
   has_many :results
 
-  validates :play_type, presence: true, numericality: { in: 3..4 }
+  validates :play_type, presence: true, inclusion: { in: [3, 4] }
   validates :name, presence: true, uniqueness: { scope: :player }, length: { maximum: 15 }
   validates :mochi, :kaeshi, :uma_one, :uma_two, :uma_three, :uma_four, :score_decimal_point_calc, presence: true
   validates :is_chip, inclusion: [true, false] # boolean型のpresenceチェック

--- a/app/views/matches/_form.html.haml
+++ b/app/views/matches/_form.html.haml
@@ -104,6 +104,9 @@
                 %i.fa-solid.fa-pen.pe-1.fw-bold
                 %span 登録
       .col-8.col-md-7.m-auto.mt-1
-        .d-flex.justify-content-center.align-items-center#match_create_warning
+        .d-flex.justify-content-center.align-items-center#match_create_warning_1
           %i.fa-solid.fa-triangle-exclamation.text-warning.fs-sm.pe-1
           %p.fs-sm.text-main.fw-bold.mb-0 残得点が0ではありません
+        .d-flex.justify-content-center.align-items-center#match_create_warning_2
+          %i.fa-solid.fa-triangle-exclamation.text-warning.fs-sm.pe-1
+          %p.fs-sm.text-main.fw-bold.mb-0 家が重複しています

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -4,7 +4,6 @@ require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
     config.storage :fog
-    config.fog_provider = 'fog/aws'
     config.fog_directory  = 'janreco-s3' # 作成したバケット名
     config.fog_credentials = {
       provider: 'AWS',

--- a/spec/factories/leagues.rb
+++ b/spec/factories/leagues.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :league do
+    name { 'test_league' }
+    play_type { 4 }
+    description { 'test_description' }
+    association :player
+    association :rule
+  end
+end

--- a/spec/factories/match_groups.rb
+++ b/spec/factories/match_groups.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :match_group do
+    association :rule
+    association :league
+  end
+end

--- a/spec/factories/players.rb
+++ b/spec/factories/players.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :player do
-    sequence(:name, "player_1")
+    sequence(:name) { |n| "p#{n}" } # 名前が一意になり、8文字以内になるようにします。
   end
 end

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -1,6 +1,12 @@
+require 'factory_bot'
+
 FactoryBot.define do
   factory :result do
     association :match
     association :player
+    score { 30000 }
+    ie { 1 }
+    point  { 30 }
+    rank { 1 }
   end
 end

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe League, type: :model do
+
+end

--- a/spec/models/match_group_spec.rb
+++ b/spec/models/match_group_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe MatchGroup, type: :model do
+  let(:player) { create(:player) }
+  # let(:match_group) { create(:match_group) }
+  # let(:match) { create(:match, match_group: match_group) }
+  # let(:result) { create(:result, player: player, match: match) }
+
+  let(:rule) { create(:rule) }
+  let(:match_group) { create(:match_group, play_type: rule.play_type) }
+  let(:match) { create(:match, rule: rule, play_type: rule.play_type) }
+  let!(:result) { create(:result, player: player, match: match) } # `let!`を使用して即時評価
+
+
+  # describe '#table_element' do
+  #   it '各マッチの結果と合計ポイントを返すこと' do
+  #     each_points, total_points = match_group.table_element
+  #     expect(each_points).to eq [[result.point]]
+  #     expect(total_points).to eq [result.point]
+  #   end
+  # end
+
+  # describe '#get_index' do
+  #   it 'マッチのインデックスを返すこと' do
+  #     expect(match_group.get_index(match.id)).to eq 1
+  #   end
+  # end
+
+  # describe '#players' do
+  #   it 'マッチグループのプレイヤーを返すこと' do
+  #     expect(match_group.players).to contain_exactly(player)
+  #   end
+  # end
+
+  # describe '#created_by?' do
+  #   context '現在のプレイヤーが作成者である場合' do
+  #     it 'trueを返すこと' do
+  #       expect(match_group.created_by?(player)).to be true
+  #     end
+  #   end
+
+  #   context '現在のプレイヤーが作成者でない場合' do
+  #     let(:other_player) { create(:player) }
+
+  #     it 'falseを返すこと' do
+  #       expect(match_group.created_by?(other_player)).to be false
+  #     end
+  #   end
+  # end
+end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe Match, type: :model do
+  let(:rule) { create(:rule) }
+  let(:match) { build(:match, rule: rule) }
+
+  # ====================
+  # バリデーション
+  # ====================
+  describe '#validations' do
+    describe '#play_type' do
+      context '存在しない場合' do
+        it 'バリデーションエラーとなること' do
+          match.play_type = nil
+          match.valid?
+          expect(match.errors[:play_type]).to include("を入力してください")
+        end
+      end
+
+      context '3より小さい場合' do
+        it 'バリデーションエラーとなること' do
+          match.play_type = 2
+          match.valid?
+          expect(match.errors[:play_type]).to include("は一覧にありません")
+        end
+      end
+    end
+
+    describe '#match_on' do
+      context '存在しない場合' do
+        it 'バリデーションエラーとなること' do
+          match.match_on = nil
+          match.valid?
+          expect(match.errors[:match_on]).to include("を入力してください")
+        end
+      end
+    end
+
+    describe '#rule_id' do
+      context '存在しない場合' do
+        it 'バリデーションエラーとなること' do
+          match.rule_id = nil
+          match.valid?
+          expect(match.errors[:rule_id]).to include("を入力してください")
+        end
+      end
+    end
+
+    describe '#memo' do
+      context '50文字を超える場合' do
+        it 'バリデーションエラーとなること' do
+          match.memo = 'a' * 51
+          match.valid?
+          expect(match.errors[:memo].join).to include("50文字以内で入力してください")
+        end
+      end
+    end
+  end
+
+  # ====================
+  # メソッド
+  # ====================
+  let(:player) { create(:player) }
+  let(:match) { create(:match, rule: rule, play_type: rule.play_type) }
+  let!(:result) { create(:result, player: player, match: match) } # `let!`を使用して即時評価
+  let(:player_2) { create(:player) }
+
+  describe '#current_player_point' do
+    context '該当のプレイヤーIDが存在する場合' do
+      it 'プレイヤーのポイントを返すこと' do
+        expect(match.current_player_point(player.id)).to eq result.point
+      end
+    end
+
+    context '該当のプレイヤーIDが存在しない場合' do
+      it 'nilを返すこと' do
+        expect(match.current_player_point(player_2.id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Player, type: :model do
 
     end
 
-    context 'Player#nameが10文字より大きいとき' do
+    context 'Player#nameが8文字より大きいとき' do
       it 'バリデーションエラーになること' do
-        player = build(:player, name: 'a' * 11)
+        player = build(:player, name: 'a' * 9)
         expect(player).not_to be_valid
-        expect(player.errors[:name]).to include('は10文字以内で入力してください')
+        expect(player.errors[:name]).to include('は8文字以内で入力してください')
       end
     end
   end
@@ -23,22 +23,36 @@ RSpec.describe Player, type: :model do
   # 四麻のデータ
   let(:players_4) { create_list(:player, 4) }
   let!(:rule_4) { create(:rule, player: players_4.first) }
-  let!(:match_4) { create(:match, player: players_4.first, rule: rule_4, play_type: 4) }
-
-  let!(:results_4) do
+  # 1戦目
+  let!(:match_4_1) { create(:match, player: players_4.first, rule: rule_4, play_type: 4) }
+  let!(:results_4_1) do
     players_4.each_with_index.map do |player, index|
-      create(:result, match: match_4, player: player, score: 35000 - (5000 * index), point: 30 - (20 * index), ie: index + 1, rank: index + 1)
+      create(:result, match: match_4_1, player: player, score: 35000 - (5000 * index), point: 30 - (20 * index), ie: index + 1, rank: index + 1)
+    end
+  end
+  # 2戦目
+  let!(:match_4_2) { create(:match, player: players_4.first, rule: rule_4, play_type: 4) }
+  let!(:results_4_2) do
+    players_4.each_with_index.map do |player, index|
+      create(:result, match: match_4_2, player: player, score: 20000 + (5000 * index), point: -30 + (20 * index), ie: index + 1, rank: 4 - index)
     end
   end
 
   # 三麻のデータ
   let(:players_3) { create_list(:player, 3) }
-  let!(:rule_3) { create(:rule, player: players_3.first) }
-  let!(:match_3) { create(:match, player: players_3.first, rule: rule_3, play_type: 3) }
-
-  let!(:results_3) do
+  let!(:rule_3) { create(:rule, player: players_3.first, play_type: 3) }
+  # 1戦目
+  let!(:match_3_1) { create(:match, player: players_3.first, rule: rule_3, play_type: 3) }
+  let!(:results_3_1) do
     players_3.each_with_index.map do |player, index|
-      create(:result, match: match_3, player: player, score: 35000 - (5000 * index), point: 30 - (30 * index), ie: index + 1, rank: index + 1)
+      create(:result, match: match_3_1, player: player, score: 35000 - (5000 * index), point: 30 - (30 * index), ie: index + 1, rank: index + 1)
+    end
+  end
+  # 2戦目
+  let!(:match_3_2) { create(:match, player: players_3.first, rule: rule_3, play_type: 3) }
+  let!(:results_3_2) do
+    players_3.each_with_index.map do |player, index|
+      create(:result, match: match_3_2, player: player, score: 35000 - (5000 * index), point: 30 - (30 * index), ie: index + 1, rank: index + 1)
     end
   end
 
@@ -48,34 +62,38 @@ RSpec.describe Player, type: :model do
   describe 'Player#find_by_results' do
     it 'resultからplayerが取得できること' do
       players = Player.find_by_results(players_4[0].matches.first.results)
-      expect(players).to contain_exactly(players_4[0], players_4[1], players_4[2], players_4[3])
+      expect(players).to contain_exactly(players_4[0].name, players_4[1].name, players_4[2].name, players_4[3].name)
     end
   end
+
+  # ************************************
+  # メインデータ
+  # ************************************
 
   describe 'Player#total_match_count' do
     it 'playerの総対戦数を取得できること' do
       expect(players_4[0].total_match_count(3)).to eq(0)
-      expect(players_4[0].total_match_count(4)).to eq(1)
-      expect(players_3[0].total_match_count(3)).to eq(1)
+      expect(players_4[0].total_match_count(4)).to eq(2)
+      expect(players_3[0].total_match_count(3)).to eq(2)
       expect(players_3[0].total_match_count(4)).to eq(0)
     end
   end
 
   describe 'Player#results_for_matches' do
     it 'playerが参加したmatchのresultsの取得できること' do
-      expect(players_4[0].results_for_matches(4)).to contain_exactly(results_4.first)
-      expect(players_4[0].results_for_matches(3)).not_to contain_exactly(results_3.first)
-      expect(players_3[0].results_for_matches(3)).to contain_exactly(results_3.first)
-      expect(players_3[0].results_for_matches(4)).not_to contain_exactly(results_4.first)
+      expect(players_4[0].results_for_matches(4)).to contain_exactly(results_4_1.first, results_4_2.first)
+      expect(players_4[0].results_for_matches(3)).not_to contain_exactly(results_3_1.first, results_3_2.first)
+      expect(players_3[0].results_for_matches(3)).to contain_exactly(results_3_1.first, results_3_2.first)
+      expect(players_3[0].results_for_matches(4)).not_to contain_exactly(results_4_1.first, results_4_2.first)
     end
   end
 
   describe 'Player#match_ids_for_play_type' do
     it 'play_typeに基づいて適切なmatch_idsの配列に含まれること' do
-      expect(players_4[0].match_ids_for_play_type(4)).to contain_exactly(match_4.id)
-      expect(players_4[0].match_ids_for_play_type(3)).not_to contain_exactly(match_4.id)
-      expect(players_3[0].match_ids_for_play_type(3)).to contain_exactly(match_3.id)
-      expect(players_3[0].match_ids_for_play_type(4)).not_to contain_exactly(match_3.id)
+      expect(players_4[0].match_ids_for_play_type(4)).to contain_exactly(match_4_1.id, match_4_2.id)
+      expect(players_4[0].match_ids_for_play_type(3)).not_to contain_exactly(match_4_1.id, match_4_2.id)
+      expect(players_3[0].match_ids_for_play_type(3)).to contain_exactly(match_3_1.id, match_3_2.id)
+      expect(players_3[0].match_ids_for_play_type(4)).not_to contain_exactly(match_3_1.id, match_3_2.id)
     end
   end
 
@@ -83,10 +101,10 @@ RSpec.describe Player, type: :model do
     it '直近の対局データを5局取得できること' do
       players_3[0].match_ids_for_play_type(3)
       players_4[0].match_ids_for_play_type(4)
-      expect(players_3[0].get_sanyon_matches(3)).to contain_exactly(players_3[0].matches.last)
-      expect(players_3[0].get_sanyon_matches(3)).not_to contain_exactly(players_4[0].matches.last)
-      expect(players_4[0].get_sanyon_matches(4)).to contain_exactly(players_4[0].matches.last)
-      expect(players_4[0].get_sanyon_matches(4)).not_to contain_exactly(players_3[0].matches.last)
+      expect(players_3[0].get_sanyon_matches(3)).to eq(Match.match_ids(players_3[0].match_ids, 3).desc.first(2))
+      expect(players_3[0].get_sanyon_matches(3)).not_to eq(Match.match_ids(players_4[0].match_ids, 3).desc.first(2))
+      expect(players_4[0].get_sanyon_matches(4)).to eq(Match.match_ids(players_4[0].match_ids, 4).desc.first(2))
+      expect(players_4[0].get_sanyon_matches(4)).not_to eq(Match.match_ids(players_3[0].match_ids, 4).desc.first(2))
     end
   end
 
@@ -94,10 +112,10 @@ RSpec.describe Player, type: :model do
     it 'play_typeに基づくmatch_idsを取得できること' do
       players_3[0].match_ids_for_play_type(3)
       players_4[0].match_ids_for_play_type(4)
-      expect(players_3[0].get_sanyon_match_ids(3)).to contain_exactly(players_3[0].matches.last)
-      expect(players_3[0].get_sanyon_match_ids(3)).not_to contain_exactly(players_4[0].matches.last)
-      expect(players_4[0].get_sanyon_match_ids(4)).to contain_exactly(players_4[0].matches.last)
-      expect(players_4[0].get_sanyon_match_ids(4)).not_to contain_exactly(players_3[0].matches.last)
+      expect(players_3[0].get_sanyon_match_ids(3)).to eq(players_3[0].matches.to_a)
+      expect(players_3[0].get_sanyon_match_ids(3)).not_to eq(players_4[0].matches.to_a)
+      expect(players_4[0].get_sanyon_match_ids(4)).to eq(players_4[0].matches.to_a)
+      expect(players_4[0].get_sanyon_match_ids(4)).not_to eq(players_3[0].matches.to_a)
     end
   end
 
@@ -105,11 +123,13 @@ RSpec.describe Player, type: :model do
     let(:players) { create_list(:player, 4) }
     context '対戦数が1以上の場合' do
       before do
+        play_type = 4
         rule_4 = create(:rule, player: players.first)
-        match_4 = create(:match, player: players.first, rule: rule_4, play_type: 4)
-        results_4 = players.each_with_index.map do |player, index|
-            create(:result, match: match_4, player: player, score: 35000 - (5000 * index), point: 30 - (20 * index), ie: index + 1, rank: index + 1)
-          end
+        match_4_1 = create(:match, player: players.first, rule: rule_4, play_type: play_type)
+        results_4_1 = players.each_with_index.map do |player, index|
+            create(:result, match: match_4_1, player: player, score: 35000 - (5000 * index), point: 30 - (20 * index), ie: index + 1, rank: index + 1)
+        end
+        allow(players[0]).to receive(:results_for_matches).and_return(players[0].results.where(match_id: players[0].match_ids_for_play_type(play_type)))
       end
       it 'trueを返すこと' do
         expect(players[0].matches_present?).to be true
@@ -123,38 +143,440 @@ RSpec.describe Player, type: :model do
     end
   end
 
-  # describe 'Player#total_point' do
-  #   it 'playerの総合ptを取得できること' do
-  #     expect(player.total_point(3)).to eq('+10.0')
-  #     expect(player.total_point(4)).to eq('+20.0')
-  #   end
-  # end
+  describe 'Player#total_point' do
+    it 'playerの総合ptを取得できること' do
+      expect(players_3[0].total_point(3)).to eq("+60.0")
+      expect(players_3[1].total_point(3)).to eq("0.0")
+      expect(players_3[2].total_point(3)).to eq("-60.0")
+      expect(players_4[0].total_point(4)).to eq("0.0")
+      expect(players_4[1].total_point(4)).to eq("0.0")
+      expect(players_4[2].total_point(4)).to eq("0.0")
+      expect(players_4[3].total_point(4)).to eq("0.0")
+    end
+  end
 
-  # describe 'Player#average_rank' do
-  #   it 'playerの平均順位を取得できること' do
-  #     expect(player.average_rank).to eq('1.50')
-  #   end
-  # end
+  describe 'Player#average_rank' do
+    before do
+      setup_results_for_matches
+    end
+    it 'playerの平均順位を取得できること' do
+      expect(players_3[0].average_rank).to eq('1.00')
+      expect(players_3[1].average_rank).to eq('2.00')
+      expect(players_3[2].average_rank).to eq('3.00')
+      expect(players_4[0].average_rank).to eq('2.50')
+      expect(players_4[1].average_rank).to eq('2.50')
+      expect(players_4[2].average_rank).to eq('2.50')
+      expect(players_4[3].average_rank).to eq('2.50')
+    end
+    it 'playerの対局数が０の場合はハイフンを返すこと' do
+      expect(player_0.average_rank).to eq(' - ')
+    end
+  end
 
-  # describe 'Player#rentai_rate' do
-  #   it 'playerの連対率を取得できること' do
-  #     expect(player.rentai_rate).to eq('100.00')
-  #   end
-  # end
+  describe 'Player#rentai_rate' do
+    before do
+      setup_results_for_matches
+    end
+    it 'playerの連対率を取得できること' do
+      expect(players_3[0].rentai_rate).to eq('100.00')
+      expect(players_3[1].rentai_rate).to eq('100.00')
+      expect(players_3[2].rentai_rate).to eq('0.00')
+      expect(players_4[0].rentai_rate).to eq('50.00')
+      expect(players_4[1].rentai_rate).to eq('50.00')
+      expect(players_4[2].rentai_rate).to eq('50.00')
+      expect(players_4[3].rentai_rate).to eq('50.00')
+    end
+    it 'playerの対局数が0の場合はハイフンを返すこと' do
+      expect(player_0.rentai_rate).to eq(' - ')
+    end
 
-  # describe 'Player#graph_rank_data' do
-  #   it '順位グラフ用データをセットできること' do
-  #     expect(player.graph_rank_data(3)).to eq({ '3' => [1] })
-  #     expect(player.graph_rank_data(4)).to eq({ '4' => [2] })
-  #   end
-  # end
+  end
 
-  # describe 'Player#add_null' do
-  #   it 'rank_dataが10個未満の場合はnilで埋めること' do
-  #     rank_data = [1, 2, 3]
-  #     player.add_null(rank_data)
-  #     expect(rank_data).to eq([1, 2, 3, nil, nil, nil, nil, nil, nil, nil])
-  #   end
-  # end
+  describe 'Player#graph_rank_data' do
+    before do
+      players_3.each do |player|
+        player.match_ids_for_play_type(3)
+        allow(player).to receive(:get_sanyon_match_ids).and_return(Match.match_ids(player.match_ids, 3))
+      end
+      players_4.each do |player|
+        player.match_ids_for_play_type(4)
+        allow(player).to receive(:get_sanyon_match_ids).and_return(Match.match_ids(player.match_ids, 4))
+      end
+    end
 
+    it '順位グラフ用データをセットできること' do
+      expect(players_3[0].graph_rank_data(3)).to eq({3 => [1, 1, nil, nil, nil, nil, nil, nil, nil, nil,] })
+      expect(players_3[1].graph_rank_data(3)).to eq({3 => [2, 2, nil, nil, nil, nil, nil, nil, nil, nil,] })
+      expect(players_3[2].graph_rank_data(3)).to eq({3 => [3, 3, nil, nil, nil, nil, nil, nil, nil, nil,] })
+      expect(players_4[0].graph_rank_data(4)).to eq({4 => [1, 4, nil, nil, nil, nil, nil, nil, nil, nil,] })
+      expect(players_4[1].graph_rank_data(4)).to eq({4 => [2, 3, nil, nil, nil, nil, nil, nil, nil, nil,] })
+      expect(players_4[2].graph_rank_data(4)).to eq({4 => [3, 2, nil, nil, nil, nil, nil, nil, nil, nil,] })
+      expect(players_4[3].graph_rank_data(4)).to eq({4 => [4, 1, nil, nil, nil, nil, nil, nil, nil, nil,] })
+    end
+  end
+
+  describe 'Player#add_null' do
+    it 'rank_dataが10個未満の場合はnilで埋めること' do
+      rank_data = [1, 2, 3]
+      players_4[0].add_null(rank_data)
+      expect(rank_data).to eq([1, 2, 3, nil, nil, nil, nil, nil, nil, nil])
+    end
+    it 'rank_dataが10個以上の場合はnilで埋めない' do
+      rank_data = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2]
+      players_4[0].add_null(rank_data)
+      expect(rank_data).to eq([1, 2, 3, 4, 1, 2, 3, 4, 1, 2])
+    end
+  end
+
+  # ************************************
+  # 順位別データ
+  # ************************************
+  describe '#rank_results' do
+    let(:player) { Player.new }
+
+    it '成績なしの場合、-と0を返すこと' do
+      expect(player.rank_results(3)).to eq([[" - ", 0], [" - ", 0], [" - ", 0]])
+      expect(player.rank_results(4)).to eq([[" - ", 0], [" - ", 0], [" - ", 0], [" - ", 0]])
+    end
+
+    it '成績ありで、三麻の場合配列が3つであること' do
+      expect(players_3[0].rank_results(3).size).to eq(3)
+      expect(players_3[1].rank_results(3).size).to eq(3)
+      expect(players_3[2].rank_results(3).size).to eq(3)
+    end
+
+    it '成績ありで、四麻の場合配列が4つであること' do
+      expect(players_4[0].rank_results(4).size).to eq(4)
+      expect(players_4[1].rank_results(4).size).to eq(4)
+      expect(players_4[2].rank_results(4).size).to eq(4)
+      expect(players_4[3].rank_results(4).size).to eq(4)
+    end
+  end
+
+  describe '#rank_rate' do
+    let(:player) { Player.new }
+    context 'when rank_times sum is zero' do
+      before do
+        allow(player).to receive(:rank_times).and_return([0, 0, 0, 0])
+      end
+
+      it '順位回数が0である場合、ハイフンを返すこと' do
+        expect(player.rank_rate).to eq(Player::HYPHENS)
+      end
+    end
+
+    context '順位回数が0でない場合、ハイフンを返すこと' do
+      before do
+        allow(player).to receive(:rank_times).and_return([1, 2, 3, 4])
+        allow(player).to receive(:total_match_count).and_return(10)
+      end
+
+      it '順位率を返すこと' do
+        expect(player.rank_rate).to eq(['10.0', '20.0', '30.0', '40.0'])
+      end
+    end
+  end
+
+  describe '#rank_times' do
+    it '順位回数を返すこと' do
+      expect(players_3[0].rank_times(3)).to eq([2, 0, 0, 0])
+      expect(players_3[1].rank_times(3)).to eq([0, 2, 0, 0])
+      expect(players_3[2].rank_times(3)).to eq([0, 0, 2, 0])
+      expect(players_4[0].rank_times(4)).to eq([1, 0, 0, 1])
+      expect(players_4[1].rank_times(4)).to eq([0, 1, 1, 0])
+      expect(players_4[2].rank_times(4)).to eq([0, 1, 1, 0])
+      expect(players_4[3].rank_times(4)).to eq([1, 0, 0, 1])
+    end
+  end
+
+
+  # ************************************
+  # 家別データ
+  # ************************************
+  let(:player) { Player.new }
+
+  describe '#ie_results' do
+    it '家別データを配列で返すこと' do
+      expect(player.ie_results).to be_an_instance_of(Array)
+    end
+
+    it '家別データは配列で4つの要素であること' do
+      expect(player.ie_results.size).to eq(4)
+    end
+  end
+
+  describe '#average_rank_by_ie' do
+    before do
+      setup_results_for_matches
+    end
+
+    it '対局数が0の場合、家別の順位率をすべてハイフンの配列で返すこと' do
+      expect(player.average_rank_by_ie).to eq([" - ", " - ", " - ", " - "])
+    end
+
+    it '家別の順位率を配列で返すこと' do
+      expect(players_3[0].average_rank_by_ie).to eq(["1.0", " - ", " - ", " - "])
+      expect(players_3[1].average_rank_by_ie).to eq([" - ", "2.0", " - ", " - "])
+      expect(players_3[2].average_rank_by_ie).to eq([" - ", " - ", "3.0", " - "])
+      expect(players_4[0].average_rank_by_ie).to eq(["2.5", " - ", " - ", " - "])
+      expect(players_4[1].average_rank_by_ie).to eq([" - ", "2.5", " - ", " - "])
+      expect(players_4[2].average_rank_by_ie).to eq([" - ", " - ", "2.5", " - "])
+      expect(players_4[3].average_rank_by_ie).to eq([" - ", " - ", " - ", "2.5"])
+    end
+  end
+
+  describe '#ie_times' do
+    before do
+      setup_results_for_matches
+    end
+    it '家の回数を配列で返すこと' do
+      expect(players_3[0].ie_times).to eq([2, 0, 0, 0])
+      expect(players_3[1].ie_times).to eq([0, 2, 0, 0])
+      expect(players_3[2].ie_times).to eq([0, 0, 2, 0])
+      expect(players_4[0].ie_times).to eq([2, 0, 0, 0])
+      expect(players_4[1].ie_times).to eq([0, 2, 0, 0])
+      expect(players_4[2].ie_times).to eq([0, 0, 2, 0])
+      expect(players_4[3].ie_times).to eq([0, 0, 0, 2])
+    end
+  end
+
+  describe '#total_point_by_ie' do
+    before do
+      setup_results_for_matches
+    end
+
+    it '家別のptを配列で返すこと' do
+      expect(players_3[0].total_point_by_ie).to eq(["+60.0", "+0.0", "+0.0", "+0.0"])
+      expect(players_3[1].total_point_by_ie).to eq(["+0.0", "+0.0", "+0.0", "+0.0"])
+      expect(players_3[2].total_point_by_ie).to eq(["+0.0", "+0.0", "-60.0", "+0.0"])
+      expect(players_4[0].total_point_by_ie).to eq(["+0.0", "+0.0", "+0.0", "+0.0"])
+      expect(players_4[1].total_point_by_ie).to eq(["+0.0", "+0.0", "+0.0", "+0.0"])
+      expect(players_4[2].total_point_by_ie).to eq(["+0.0", "+0.0", "+0.0", "+0.0"])
+      expect(players_4[3].total_point_by_ie).to eq(["+0.0", "+0.0", "+0.0", "+0.0"])
+    end
+  end
+
+  # ************************************
+  # よく遊ぶプレイヤーデータ
+  # ************************************
+  let!(:main_player) { create(:player) }
+  let!(:other_players) { create_list(:player, 6) }
+  let!(:matches) { create_list(:match, 5, player: main_player, rule: rule_4, play_type: 4) }
+  let!(:match_players) do
+    [
+      [main_player, other_players[4], other_players[3], other_players[2]],
+      [main_player, other_players[4], other_players[3], other_players[2]],
+      [main_player, other_players[4], other_players[3], other_players[2]],
+      [main_player, other_players[4], other_players[3], other_players[1]],
+      [main_player, other_players[4], other_players[1], other_players[0]]
+    ]
+  end
+  let!(:results) do
+    match_players.each_with_index do |players, match_index|
+      players.each_with_index.map do |m_player, i|
+        create(:result, match: matches[match_index], player: m_player, score: 35000 - (5000 * i), point: 30 - (20 * i), ie: i + 1, rank: i + 1)
+      end
+    end
+  end
+  describe '#often_play_times' do
+    before do
+      allow(main_player).to receive(:results_for_matches).and_return(main_player.results.where(match_id: main_player.match_ids_for_play_type(4)))
+      allow(players_4[0]).to receive(:results_for_matches).and_return(players_4[0].results.where(match_id: players_4[0].match_ids_for_play_type(4)))
+    end
+    context 'よく遊ぶプレイヤーが5人以上いる場合' do
+      it 'プレイヤー名と回数を返すこと' do
+        often_play_players = main_player.often_play_times
+        expect(often_play_players).to eq([
+                                        [other_players[4].id, 5],
+                                        [other_players[3].id, 4],
+                                        [other_players[2].id, 3],
+                                        [other_players[1].id, 2],
+                                        [other_players[0].id, 1]])
+      end
+    end
+
+    context 'よく遊ぶプレイヤーが5人未満の場合' do
+      it 'ハイフンと0で配列を埋めて返すこと' do
+        often_play_players = players_4[0].often_play_times
+        expect(often_play_players.size).to eq(5)
+        expect(often_play_players.count { |player_id, times| player_id == Player::HYPHEN && times == 0 }).to eq(2)
+      end
+    end
+  end
+
+  # ************************************
+  # 最高得点・最低得点
+  # ************************************
+  describe '#max_score' do
+    before do
+      setup_results_for_matches
+    end
+    it '最高得点を返すこと' do
+      expect(players_3[0].max_score(3)).to eq(35000)
+      expect(players_3[1].max_score(3)).to eq(30000)
+      expect(players_3[2].max_score(3)).to eq(25000)
+      expect(players_4[0].max_score(4)).to eq(35000)
+      expect(players_4[1].max_score(4)).to eq(30000)
+      expect(players_4[2].max_score(4)).to eq(30000)
+      expect(players_4[3].max_score(4)).to eq(35000)
+    end
+  end
+
+  describe '#max_score_match_id' do
+    before do
+      setup_results_for_matches
+    end
+    it '最高得点のマッチIDを返すこと' do
+      expect(players_3[0].max_score_match_id(3)).to eq(match_3_1.id)
+      expect(players_3[1].max_score_match_id(3)).to eq(match_3_1.id)
+      expect(players_3[2].max_score_match_id(3)).to eq(match_3_1.id)
+      expect(players_4[0].max_score_match_id(4)).to eq(match_4_1.id)
+      expect(players_4[1].max_score_match_id(4)).to eq(match_4_1.id)
+      expect(players_4[2].max_score_match_id(4)).to eq(match_4_2.id)
+      expect(players_4[3].max_score_match_id(4)).to eq(match_4_2.id)
+    end
+  end
+
+  describe '#max_score_date' do
+    before do
+      setup_results_for_matches
+    end
+    it '最高得点のマッチの日付を返すこと' do
+      expect(players_3[0].max_score_date(3)).to eq(match_3_1.match_on.to_s(:yeardate))
+      expect(players_3[1].max_score_date(3)).to eq(match_3_1.match_on.to_s(:yeardate))
+      expect(players_3[2].max_score_date(3)).to eq(match_3_1.match_on.to_s(:yeardate))
+      expect(players_4[0].max_score_date(4)).to eq(match_4_1.match_on.to_s(:yeardate))
+      expect(players_4[1].max_score_date(4)).to eq(match_4_1.match_on.to_s(:yeardate))
+      expect(players_4[2].max_score_date(4)).to eq(match_4_2.match_on.to_s(:yeardate))
+      expect(players_4[3].max_score_date(4)).to eq(match_4_2.match_on.to_s(:yeardate))
+    end
+  end
+
+  describe '#min_score' do
+    before do
+      setup_results_for_matches
+    end
+    it '最低得点を返すこと' do
+      expect(players_3[0].min_score(3)).to eq(35000)
+      expect(players_3[1].min_score(3)).to eq(30000)
+      expect(players_3[2].min_score(3)).to eq(25000)
+      expect(players_4[0].min_score(4)).to eq(20000)
+      expect(players_4[1].min_score(4)).to eq(25000)
+      expect(players_4[2].min_score(4)).to eq(25000)
+      expect(players_4[3].min_score(4)).to eq(20000)
+    end
+  end
+
+  describe '#min_score_match_id' do
+    before do
+      setup_results_for_matches
+    end
+    it '最低得点のマッチIDを返すこと' do
+      expect(players_3[0].min_score_match_id(3)).to eq(match_3_1.id)
+      expect(players_3[1].min_score_match_id(3)).to eq(match_3_1.id)
+      expect(players_3[2].min_score_match_id(3)).to eq(match_3_1.id)
+      expect(players_4[0].min_score_match_id(4)).to eq(match_4_2.id)
+      expect(players_4[1].min_score_match_id(4)).to eq(match_4_2.id)
+      expect(players_4[2].min_score_match_id(4)).to eq(match_4_1.id)
+      expect(players_4[3].min_score_match_id(4)).to eq(match_4_1.id)
+    end
+
+  end
+
+  describe '#min_score_date' do
+    before do
+      setup_results_for_matches
+    end
+    it '最低得点のマッチの日付を返すこと' do
+      expect(players_3[0].min_score_date(3)).to eq(match_3_1.match_on.to_s(:yeardate))
+      expect(players_3[1].min_score_date(3)).to eq(match_3_1.match_on.to_s(:yeardate))
+      expect(players_3[2].min_score_date(3)).to eq(match_3_1.match_on.to_s(:yeardate))
+      expect(players_4[0].min_score_date(4)).to eq(match_4_2.match_on.to_s(:yeardate))
+      expect(players_4[1].min_score_date(4)).to eq(match_4_2.match_on.to_s(:yeardate))
+      expect(players_4[2].min_score_date(4)).to eq(match_4_1.match_on.to_s(:yeardate))
+      expect(players_4[3].min_score_date(4)).to eq(match_4_1.match_on.to_s(:yeardate))
+    end
+  end
+
+  # ************************************
+  # ユーザー招待リンク用
+  # ************************************
+  describe '#create_invite_token' do
+    let(:player) { create(:player) }
+    it '招待トークンを発行し、DBに保存すること' do
+      expect { player.create_invite_token }.to change { player.invite_token }.from(nil)
+    end
+  end
+
+  describe '#invitation_players' do
+    it 'current_playerが招待可能な全プレイヤーを取得すること' do
+      players_4[0].cp = players_4[0]
+      players_4[0].recorded_players
+      expect(players_4[0].invitation_players.size).to eq(3)
+    end
+  end
+
+  describe '#recorded_match_ids' do
+    it 'current_playerが記録した対局idを配列で取得すること' do
+      players_4[0].cp = players_4[0]
+      expect(players_4[0].recorded_match_ids).to eq([match_4_1.id, match_4_2.id])
+    end
+  end
+
+  describe '#recorded_players' do
+    it 'current_playerが成績記録したプレイヤーを配列で取得すること' do
+      players_4[0].cp = players_4[0]
+      players_4[0].recorded_match_ids
+      expect(players_4[0].recorded_players).to eq([players_4[1].id, players_4[2].id, players_4[3].id])
+    end
+  end
+  # ************************************
+  # 登録したルール
+  # ************************************
+  describe '#rule_list' do
+    it '指定したplay_typeに一致するルールをすべて取得すること' do
+      expect(players_4[0].rule_list(4)).to include(rule_4)
+      expect(players_3[0].rule_list(3)).to include(rule_3)
+      expect(players_4[0].rule_list(3)).not_to include(rule_3)
+      expect(players_3[0].rule_list(4)).not_to include(rule_4)
+    end
+  end
+  # ************************************
+  # リーグ用メソッド
+  # ************************************
+  let(:player) { create(:player) }
+  let(:rule) { create(:rule) }
+  let(:league) { create(:league, player: player, rule: rule) }
+
+  describe '#leagues_registered?' do
+    context 'プレイヤーがリーグを登録している場合' do
+      before do
+        player.leagues << league
+      end
+
+      it '真を返すこと' do
+        expect(player.leagues_registered?).to be true
+      end
+    end
+
+    context 'プレイヤーがリーグを登録していない場合' do
+      it '偽を返すこと' do
+        expect(player.leagues_registered?).to be false
+      end
+    end
+  end
+
+  # ====================================
+  # 共通メソッド
+  # ====================================
+  private
+
+  def setup_results_for_matches
+    players_3.each do |player|
+      allow(player).to receive(:results_for_matches).and_return(player.results.where(match_id: player.match_ids_for_play_type(3)))
+    end
+    players_4.each do |player|
+      allow(player).to receive(:results_for_matches).and_return(player.results.where(match_id: player.match_ids_for_play_type(4)))
+    end
+  end
 end

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe Rule, type: :model do
+  let(:player) { create(:player) }
+  let(:rule_1) { create(:rule, player: player) }
+
+  # ====================
+  # バリデーション
+  # ====================
+  describe '#validations' do
+    describe '#play_type' do
+      context "Rule#play_typeが空白の場合" do
+        it 'バリデーションエラーとなること' do
+          rule = build(:rule, play_type: nil)
+          expect(rule).not_to be_valid
+          expect(rule.errors[:play_type]).to include("を入力してください")
+        end
+      end
+      context "Rule#play_typeが3か4以外の場合" do
+        it 'バリデーションエラーとなること' do
+          rule = build(:rule, play_type: 5)
+          expect(rule).not_to be_valid
+          expect(rule.errors[:play_type]).to include("は一覧にありません")
+        end
+      end
+    end
+
+    describe '#name' do
+      context "Rule#nameが空白の場合" do
+        it 'バリデーションエラーとなること' do
+          rule = build(:rule, name: nil)
+          expect(rule).not_to be_valid
+          expect(rule.errors[:name]).to include("を入力してください")
+        end
+      end
+      context "Rule#nameが15文字以上の場合" do
+        it 'バリデーションエラーとなること' do
+          rule = build(:rule, name: 'aaaaabbbbbcccccd')
+          expect(rule).not_to be_valid
+          expect(rule.errors[:name].join).to include("15文字以内で入力してください")      end
+      end
+      context "Rule#nameが同じプレイヤーで重複している場合" do
+        it 'バリデーションエラーとなること' do
+          rule = build(:rule, name: rule_1.name, player: player)
+          expect(rule).not_to be_valid
+          expect(rule.errors[:name]).to include("はすでに存在します")
+        end
+      end
+    end
+
+    let(:rule) { build(:rule, player: player) }
+
+    describe '#mochi' do
+      context "存在しない場合" do
+        it 'バリデーションエラーとなること' do
+          rule.mochi = nil
+          expect(rule).not_to be_valid
+          expect(rule.errors[:mochi]).to include("を入力してください")
+        end
+      end
+    end
+
+    describe '#is_chip' do
+      context "trueまたはfalseでない場合" do
+        it 'バリデーションエラーとなること' do
+          rule.is_chip = nil
+          expect(rule).not_to be_valid
+          expect(rule.errors[:is_chip]).to include("は一覧にありません")
+        end
+      end
+    end
+
+    describe '#chip_rate' do
+      context "is_chipがtrueで存在しない場合" do
+        it 'バリデーションエラーとなること' do
+          rule.is_chip = true
+          rule.chip_rate = nil
+          expect(rule).not_to be_valid
+          expect(rule.errors[:chip_rate]).to include("を入力してください")
+        end
+      end
+
+      context "is_chipがfalseで存在する場合" do
+        it 'バリデーションエラーとなること' do
+          rule.is_chip = false
+          rule.chip_rate = 10
+          expect(rule).not_to be_valid
+          expect(rule.errors[:chip_rate]).to include("は入力しないでください")
+        end
+      end
+    end
+
+    describe '#description' do
+      context "50文字を超える場合" do
+        it 'バリデーションエラーとなること' do
+          rule.description = 'a' * 51
+          expect(rule).not_to be_valid
+          expect(rule.errors[:description].join).to include("50文字以内で入力してください")
+        end
+      end
+    end
+  end
+
+  # ====================
+  # メソッド
+  # ====================
+  describe '.get_value_score_decimal_point_calc' do
+    it 'コード値に対応する文字列を返すこと' do
+      expect(Rule.get_value_score_decimal_point_calc(1)).to eq '小数点有効'
+      expect(Rule.get_value_score_decimal_point_calc(2)).to eq '五捨六入'
+      expect(Rule.get_value_score_decimal_point_calc(3)).to eq '四捨五入'
+      expect(Rule.get_value_score_decimal_point_calc(4)).to eq '切り捨て'
+      expect(Rule.get_value_score_decimal_point_calc(5)).to eq '切り上げ'
+      # 他のコード値についても同様にテストを追加してください
+    end
+  end
+
+  describe '.get_value_is_chip' do
+    context 'is_chipがtrueの場合' do
+      it '「有」を返すこと' do
+        expect(Rule.get_value_is_chip(true)).to eq '有'
+      end
+    end
+
+    context 'is_chipがfalseの場合' do
+      it '「無」を返すこと' do
+        expect(Rule.get_value_is_chip(false)).to eq '無'
+      end
+    end
+  end
+
+  describe '.get_value_chip_rate' do
+    context 'chip_rateがnilの場合' do
+      it '「-」を返すこと' do
+        expect(Rule.get_value_chip_rate(nil)).to eq '-'
+      end
+    end
+
+    context 'chip_rateが存在する場合' do
+      it 'chip_rateに"pt"を追加した文字列を返すこと' do
+        expect(Rule.get_value_chip_rate(10)).to eq '10pt'
+      end
+    end
+  end
+
+  # ====================
+  # カスタムバリデーション
+  # ====================
+  describe '#mochi_kaeshi_check' do
+    let(:player) { create(:player) }
+    let(:rule) { build(:rule, player: player) }
+    context '持ち点が返し点より大きい場合' do
+      it 'エラーが追加されること' do
+        rule.mochi = 35000
+        rule.kaeshi = 30000
+        rule.valid?
+        expect(rule.errors[:kaeshi]).to include('点は持ち点より大きくしてください')
+      end
+    end
+
+    context '持ち点が返し点より小さい場合' do
+      it 'エラーが追加されないこと' do
+        rule.mochi = 25000
+        rule.kaeshi = 30000
+        rule.valid?
+        expect(rule.errors[:kaeshi]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "User#nameが10文字より大きいとき" do
+    context "User#nameが8文字より大きいとき" do
       it 'バリデーションエラーとなること' do
-        user = build(:user, name: 'a' * 11)
+        user = build(:user, name: 'a' * 9)
         expect(user).not_to be_valid
-        expect(user.errors[:name]).to include('は10文字以内で入力してください')
+        expect(user.errors[:name]).to include('は8文字以内で入力してください')
       end
     end
   end


### PR DESCRIPTION
## 動作確認

<!-- PCで動かした場合の動作確認を動画で貼る or 見た目のみの作成で機能が必要ない場合は画像でOK -->
**PCの動作確認動画**

## やったこと
<!-- 実装した内容を書く-->
- pr_0211
    - テスト追加
        - player
        - rule
        - match
    - バグ修正
        - 【match登録】バリデーションエラーになった際、残得点のjsが作動しない
        - 【match登録】バリデーションエラーになった際、得点が十の位以下も表示されてしまう
        - 【match登録】バリデーションエラー防止のため、対局日と家重複を条件に加えボタン状態を制御するよう修正

## 実装のリンク
<!-- ガントチャートのタスク対象のセルのリンクを貼る -->

## 備考

<!-- なければ、書かなくても良い。相談事項があれば、ここに書く。-->