### PR TITLE
Pr 0222

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -40,8 +40,11 @@ class MatchesController < ApplicationController
                                           'matches_controller',
                                           @match) # トークンが有効か判定
     else
-      redirect_to(user_session_path,
-                  alert: FlashMessages::UNAUTHENTICATED) && return unless current_user #ログアウトユーザーはアクセス拒否
+      #ログアウトユーザーはアクセス拒否
+      unless current_user
+        redirect_to(user_session_path,
+                    alert: FlashMessages::UNAUTHENTICATED) && return
+      end
       # matchにcurrent_playerが含まれていない場合、アクセス不可
       unless @match.results.pluck(:player_id).include?(current_player.id) || @match_group.created_by?(current_player)
         redirect_to(root_path,
@@ -55,7 +58,11 @@ class MatchesController < ApplicationController
     @matches = @match_group.matches
     @rule = Rule.find_by(id: @match_group.rule_id)
     @last_match_day = @match_group.last_match_day
-    session[:previous_url] = request.referer unless request.referer.include?(edit_match_path)
+    if request.referer.present?
+      unless request.referer.include?(edit_match_path)
+        session[:previous_url] = request.referer
+      end
+    end
     gon_setter('show')
   end
 

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -17,7 +17,7 @@ class MatchesController < ApplicationController
       @league = League.find_by(id: params[:league])
       redirect_to(root_path, alert: FlashMessages::ACCESS_DENIED) && return unless @league
 
-      unless current_player.id == League.find_by(id: params[:league]).player_id
+      unless league_record_permit?
         alert_redirect_root(FlashMessages::CANNOT_RECORD_LEAGUE)
       end
       # リーグ成績を記録中、他のリーグ成績の登録不可
@@ -197,6 +197,12 @@ class MatchesController < ApplicationController
     @match.play_type = @players.count
     session_players_num.times { @match.results.build }
     gon_setter('new')
+  end
+
+  # リーグ戦において記録可能プレイヤーか真偽値を返す
+  def league_record_permit?
+    (current_player.id == League.find_by(id: params[:league]).player_id) ||
+      LeaguePlayer.exists?(player_id: current_player.id, league_id: params[:league])
   end
 
   # ***************** destroyアクション ************************ #

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -26,4 +26,10 @@ class Match < ApplicationRecord
   def current_player_point(p_id)
     results.find_by(player_id: p_id)&.point
   end
+
+  # match_groupの作成者の名前を返す
+  def create_player_name
+    match.player.name
+  end
+
 end

--- a/app/models/match_group.rb
+++ b/app/models/match_group.rb
@@ -45,6 +45,11 @@ class MatchGroup < ApplicationRecord
     matches.first.player_id == current_player.id
   end
 
+  # match_groupの作成者の名前を返す
+  def create_player_name
+    matches.first.player.name
+  end
+
   # 成績表においてチップレコードかどうか
   def chip_record?(idx)
     tip_rule? && matches.count < idx + 1

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -260,8 +260,8 @@ class Player < ApplicationRecord
   # ************************************
   # リーグ用メソッド
   # ************************************
-  # プレイヤーがリーグを登録しているか
+  # プレイヤーがリーグ参加しているか
   def leagues_registered?
-    leagues.count.positive?
+    LeaguePlayer.exists?(player_id: id)
   end
 end

--- a/app/views/leagues/index.html.haml
+++ b/app/views/leagues/index.html.haml
@@ -25,15 +25,14 @@
                     - else
                       %span -
                 .col-3.league_item-center.px-1
-                  - record_active = league.league_players.present? && league.player_id == current_player.id
-                  - result_active = league.league_players.present?
+                  - active = league.league_players.present?
                   = link_to new_match_path(league: league.id),
-                    class: "main-btn--white-orange-sm py-2 px-1 my-1 #{'inactive-link' unless record_active}" do
+                    class: "main-btn--white-orange-sm py-2 px-1 my-1 #{'inactive-link' unless active}" do
                     .btn-text
                       %i.fa-solid.fa-pen
                       %span 記録
                   = link_to league_path(league),
-                    class: "main-btn--white-green-sm py-2 px-1 my-1 #{'inactive-link' unless result_active}" do
+                    class: "main-btn--white-green-sm py-2 px-1 my-1 #{'inactive-link' unless active}" do
                     .btn-text
                       %i.fa-solid.fa-chart-simple
                       %span 成績

--- a/app/views/match_groups/_result_table.html.haml
+++ b/app/views/match_groups/_result_table.html.haml
@@ -5,17 +5,20 @@
         .left-content.d-flex.align-items-end
           %h4.text-center.text-md-start.text-nowrap.fw-bold.mb-0
             成績表
+
         - if request.path == match_group_path(@match_group)
           .right-content
-            - if @match_group.created_by?(current_player)
-              = link_to match_group_path(@match_group),
-                  data: { confirm: "対局成績表を削除しますか？" },
-                  method: :delete,
-                  class: 'px-1 pb-0 text-main' do
-                %i.fa-regular.fa-trash-can.me-2
+            .d-flex.align-items-end
+              %p.mb-0.fs-sm.px-2="記録者 : #{@match_group.create_player_name}"
+              - if @match_group.created_by?(current_player)
+                = link_to match_group_path(@match_group),
+                    data: { confirm: "対局成績表を削除しますか？" },
+                    method: :delete,
+                    class: 'px-1 pb-0 text-main' do
+                  %i.fa-regular.fa-trash-can.me-2
 
 .row.justify-content-center
-  .col-12.col-md-9.m-auto
+  .col-12.col-md-9.m-auto.px-0
     .score-card.mt-2.card
       .score-card-top
         .score-card-top-left

--- a/app/views/matches/_form.html.haml
+++ b/app/views/matches/_form.html.haml
@@ -16,15 +16,19 @@
       - if @league.present?
         = f.hidden_field :league_id, value: @league.id
       .d-flex.justify-content-between
-        #div
+        .label-info
           = f.label :ルール, class: 'title-p text-main'
           %span.p_required 必須
           - if recording? || ["edit", "update"].include?(controller.action_name)
             %span.p_warning ※変更不可
-      = f.collection_select(:rule_id, current_player.rule_list(@match.play_type),
-                            :id, :name,
-                            { selected: session[:rule] },
-                            class: 'form-control py-md-1 rounded bg-white mb-1 text-center' )
+      - if @league.present?
+        = f.select :rule_id, [[@league.rule.name, @league.rule.id]],{},
+          class: 'form-control py-md-1 rounded bg-white mb-1 text-center'
+      - else
+        = f.collection_select(:rule_id, current_player.rule_list(@match.play_type),
+                              :id, :name,
+                              { selected: session[:rule] },
+                              class: 'form-control py-md-1 rounded bg-white mb-1 text-center' )
       %button.js-rule-dropdown.mb-1.fs-sm.text-main{ type: 'button' }
         %i.fa-solid.fa-caret-right
         %span.ps-1 詳細

--- a/app/views/matches/_form.html.haml
+++ b/app/views/matches/_form.html.haml
@@ -27,7 +27,7 @@
       - else
         = f.collection_select(:rule_id, current_player.rule_list(@match.play_type),
                               :id, :name,
-                              { selected: session[:rule] },
+                              { selected: @match.rule_id },
                               class: 'form-control py-md-1 rounded bg-white mb-1 text-center' )
       %button.js-rule-dropdown.mb-1.fs-sm.text-main{ type: 'button' }
         %i.fa-solid.fa-caret-right

--- a/app/views/matches/show.html.haml
+++ b/app/views/matches/show.html.haml
@@ -74,8 +74,12 @@
               %i.ph.ph-notepad.pe-1
               %span 成績表を見る
         - else
-          = link_to match_group_path(@match_group), class: "main-btn--white-orange mb-3",
+          = link_to match_group_path(@match_group), class: "main-btn--white-orange",
             data: { "turbolinks" => false } do
             .btn-text
               %i.ph.ph-notepad.pe-1
               %span 成績表を見る
+        .match_info.col-12.text-main.py-2
+          %p.fs-sm.mb-0.text-center= "記録者: #{@match.player.name}"
+          %p.fs-sm.mb-0.text-center= "最終更新: #{@match.updated_at.to_s(:datetime)}"
+

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -49,7 +49,7 @@
               .faq-answer
                 .qa-flex
                   %span A.
-                  .a-text できません。
+                  .a-text できません。（今後実装予定）
             %li.faq-item
               .faq-question
                 .qa-flex
@@ -59,7 +59,7 @@
               .faq-answer
                 .qa-flex
                   %span A.
-                  .a-text できません。
+                  .a-text できません。（今後実装予定）
 
         .faq-category
           %h5
@@ -120,6 +120,16 @@
             %i.fa-solid.fa-circle-question.fs-sm
             リーグ戦について
           %ul.faq-list
+            %li.faq-item
+              .faq-question
+                .qa-flex
+                  %span Q.
+                  .q-text リーグ情報(リーグ名など)を編集したい
+                %span.fa.fa-chevron-down
+              .faq-answer
+                .qa-flex
+                  %span A.
+                  .a-text 「リーグ一覧」→ 編集したいリーグの「成績」ボタンからリーグ詳細画面へ遷移し、リーグ名の右横にあるボタンから編集してください。（リーグの編集ができるのはリーグ主催者のみです）
             %li.faq-item
               .faq-question
                 .qa-flex

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,2 @@
+# セッションの有効期限を設定
+Rails.application.config.session_store :cookie_store, key: '_your_app_session', expire_after: 14.days

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,3 +1,6 @@
+# DateTimeクラスの定義
+Time::DATE_FORMATS[:datetime] = '%Y/%m/%d %H:%M:%S' # 2018/01/01 00:00:00
+
 # Dateクラスの定義
 Date::DATE_FORMATS[:date] = "%-m/%-d"
 Date::DATE_FORMATS[:yeardate] = "%Y/%-m/%-d" # 2018/1/1

--- a/spec/factories/leagues.rb
+++ b/spec/factories/leagues.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :league do
-    name { 'test_league' }
+    sequence(:name) { |n| "league#{n}" }
     play_type { 4 }
     description { 'test_description' }
     association :player

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -1,7 +1,10 @@
+require 'factory_bot'
+
 FactoryBot.define do
   factory :match do
     rule_id {1}
     match_on {Date.today}
+    play_type {4}
     association :player
   end
 end

--- a/spec/factories/rules.rb
+++ b/spec/factories/rules.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     uma_two {10}
     uma_three {-10}
     uma_four  {-20}
-    score_decimal_point_calc {0}
+    score_decimal_point_calc {1}
     is_chip {false}
     play_type {4}
     association :player

--- a/spec/factories/rules.rb
+++ b/spec/factories/rules.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :rule do
     player_id {1}
-    name {"rule_1"}
+    sequence(:name) { |n| "rule#{n}" }
     mochi {25000}
     kaeshi  {30000}
     uma_one {20}

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -555,8 +555,8 @@ RSpec.describe Player, type: :model do
         player.leagues << league
       end
 
+      let!(:league_player) { create(:league_player, player: player, league: league) }
       it '真を返すこと' do
-        let(:league_player) { create(:league_player, player: player, league: league) }
         expect(player.leagues_registered?).to be true
       end
     end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -545,6 +545,7 @@ RSpec.describe Player, type: :model do
   # リーグ用メソッド
   # ************************************
   let(:player) { create(:player) }
+  let(:player_league_0) { create(:player) }
   let(:rule) { create(:rule) }
   let(:league) { create(:league, player: player, rule: rule) }
 
@@ -555,13 +556,14 @@ RSpec.describe Player, type: :model do
       end
 
       it '真を返すこと' do
+        let(:league_player) { create(:league_player, player: player, league: league) }
         expect(player.leagues_registered?).to be true
       end
     end
 
     context 'プレイヤーがリーグを登録していない場合' do
       it '偽を返すこと' do
-        expect(player.leagues_registered?).to be false
+        expect(player_league_0.leagues_registered?).to be false
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,4 +78,6 @@ RSpec.configure do |config|
     # driven_by(:rack_test) # ブラウザを使わずにテストを実行
     # Webdrivers::Chromedriver.required_version = '121.0.6167'
   end
+
+  Capybara.default_max_wait_time = 1 # ページが読み込まれるまでの待ち時間を設定
 end

--- a/spec/system/leagues_spec.rb
+++ b/spec/system/leagues_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+
+RSpec.describe League, type: :system do
+  let(:user) { create(:user) }
+  let(:current_p) { create(:player, user: user) }
+  let(:other_players) { create_list(:player, 3) }
+  let(:rule) { create(:rule, player: current_p) }
+  # 自分が作成し、自分も参加しているリーグ
+  let!(:league_1) { create(:league, player: current_p, rule: rule) }
+  let!(:league_players) do
+    players = [current_p] + other_players
+    players.each do |p|
+      create(:league_player, player: p, league: league_1)
+    end
+  end
+  # 自分が作成し、自分は参加していないリーグ
+  let!(:league_2) { create(:league, player: current_p, rule: rule) }
+  let!(:other_player) { create(:player) }
+  let!(:league_players_2) do
+    players = [other_player] + other_players
+    players.each do |p|
+      create(:league_player, player: p, league: league_2)
+    end
+  end
+  # 他人が作成し、自分も参加しているリーグ
+  let!(:league_3) { create(:league, player: other_player, rule: rule) }
+  let!(:league_players_3) do
+    other_players = create_list(:player, 2)
+    players = [current_p] + [other_player] + other_players
+    players.each do |p|
+      create(:league_player, player: p, league: league_3)
+    end
+  end
+  # 他人が作成し、自分は参加していないリーグ
+  let!(:league_4) { create(:league, player: other_player, rule: rule) }
+  let!(:league_players_4) do
+    players = [other_player] + other_players
+    players.each do |p|
+      create(:league_player, player: p, league: league_4)
+    end
+  end
+  # 自分が作成し、プレイヤー未選択のリーグ
+  let!(:league_5) { create(:league, player: current_p, rule: rule) }
+
+
+  describe '● ACCESS' do
+    describe '------ ログイン前 -------' do
+      describe 'Leagues#index' do
+        context 'リーグ一覧ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit leagues_path
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+      describe 'Leagues#show' do
+        context 'リーグ詳細ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit league_path(league_1)
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+      describe 'Leagues#new' do
+        context 'リーグ作成ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit new_league_path
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+      describe 'Leagues#edit' do
+        context 'リーグ編集ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit edit_league_path(league_1)
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+    end
+    describe '------ ログイン後 -------' do
+      before do
+        login(user, current_p)
+      end
+      describe 'Leagues#index' do
+        context 'リーグ一覧ページへアクセスした場合' do
+          it 'アクセス成功し、自分が作成したリーグ・参加しているリーグが表示される' do
+            visit leagues_path
+            expect(current_path).to eq leagues_path
+            expect(page).to have_content 'リーグ一覧'
+            expect(page).to have_css('.league_item', count: 4)
+            expect(page).to have_content league_1.name
+            expect(page).to have_content league_2.name
+            expect(page).to have_content league_3.name
+            expect(page).to have_content league_5.name
+            expect(page).to have_css('.inactive-link', count: 2) # league_5の記録/成績ボタンは非活性
+            expect(page).to have_link('プレイヤー選択へ', href: new_player_path(play_type: league_5.play_type, league: league_5.id))
+            expect(page).to have_link('削除', href: league_path(league_5))
+          end
+        end
+      end
+      describe 'Leagues#new' do
+        context 'リーグ詳細ページへアクセスした場合' do
+          it 'アクセス成功し、~' do
+
+          end
+        end
+      end
+      describe 'Leagues#new' do
+        context 'リーグ作成ページへアクセスした場合' do
+          it 'アクセス成功し、フォームのjs正常作動する' do
+            rule_no_tip = create(:rule, player: current_p, is_chip: false)
+            visit new_league_path
+            rule = current_p.rule_list(4).first
+            expect(current_path).to eq new_league_path
+            expect(page).to have_content 'リーグ作成'
+            # ルール詳細ボタンをクリックすると、ルール詳細が表示される
+            find('.js-rule-dropdown', visible: true).click
+            expect(page).to have_css('.js-rule-details', count: 1)
+            expect(page).to have_content "#{rule.mochi}点持ち / #{rule.kaeshi}点返し"
+            expect(page).to have_content "ウマ (#{rule.uma_one},#{rule.uma_two},#{rule.uma_three},#{rule.uma_four})"
+            expect(page).to have_content "点数計算 : #{Rule.get_value_score_decimal_point_calc(rule.score_decimal_point_calc)}"
+            expect(page).to have_content "チップ : #{Rule.get_value_is_chip(rule.is_chip)}"
+            # チップなしルールを選択すると、"リーグ成績にチップptを含めるか"の選択が非表示になる
+            select rule_no_tip.name, from: 'league_rule_id'
+            expect(page).to have_css('.js-rule-details', count: 1)
+            expect(page).to have_content "#{rule_no_tip.mochi}点持ち / #{rule_no_tip.kaeshi}点返し"
+            expect(page).to have_content "ウマ (#{rule_no_tip.uma_one},#{rule_no_tip.uma_two},#{rule_no_tip.uma_three},#{rule_no_tip.uma_four})"
+            expect(page).to have_content "点数計算 : #{Rule.get_value_score_decimal_point_calc(rule_no_tip.score_decimal_point_calc)}"
+            expect(page).to have_content "チップ : #{Rule.get_value_is_chip(rule_no_tip.is_chip)}"
+          end
+        end
+      end
+      describe 'Leagues#edit' do
+        context 'リーグ編集ページへアクセスした場合' do
+          it 'アクセス成功し、~' do
+
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/spec/system/matches_spec.rb
+++ b/spec/system/matches_spec.rb
@@ -1,0 +1,189 @@
+require 'rails_helper'
+
+RSpec.describe Match, type: :system do
+  let(:user) { create(:user) }
+  let(:player) { create(:player, user: user) }
+  let(:players) { create_list(:player, 3, user: nil) }
+  let(:rule) { create(:rule, player: player) }
+  let(:match_group) { create(:match_group, rule: rule) }
+  let(:match) { create(:match, player: player, rule: rule, match_group_id: match_group.id) }
+  let(:points) { [50, 10, -20, -40] }
+  let!(:results) do
+    players_1 = players + [player]
+    players_1.each_with_index.map do |player, index|
+      create(:result, match: match, player: player, score: 40000 - (10000 * index), point: points[index], ie: index + 1, rank: index + 1)
+    end
+  end
+  let(:other_user) { create(:user ) }
+  let(:other_player) { create(:player, user: other_user) }
+  let(:other_players) { create_list(:player, 2, user: nil) }
+
+  describe '● ACCESS' do
+    describe '------ ログイン前 -------' do
+      describe 'Matches#index' do
+        context '対局一覧ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit matches_path
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+      describe 'Matches#show' do
+        context '対局詳細ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit match_path(match)
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+      describe 'Matches#new' do
+        context '対局登録ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit new_match_path
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+      describe 'Matches#edit' do
+        context '対局編集ページへアクセスした場合' do
+          it 'アクセス失敗' do
+            visit edit_match_path(match)
+            expect(current_path).to eq new_user_session_path
+            expect(page).to have_content 'ログインもしくはアカウント登録してください'
+          end
+        end
+      end
+
+      describe '------ 共有リンク -------' do
+        describe 'Matches#show' do
+          context '不正な共有リンク(token誤り)から対局詳細ページへアクセスした場合' do
+            it 'アクセス失敗' do
+              visit match_path(match, tk: 'aaa', resource_type: 'MatchGroup')
+              expect(current_path).to eq root_path
+              expect(page).to have_content '無効なリンクです。リンク発行者に再発行をお願いしてください'
+            end
+          end
+          context '不正な共有リンク(resource_type誤り)から対局詳細ページへアクセスした場合' do
+            it 'アクセス失敗' do
+              share_link = create(:share_link, user: user, resource_id: match_group.id, resource_type: 'MatchGroup')
+              visit match_path(match, tk: share_link.token, resource_type: 'League')
+              expect(current_path).to eq root_path
+              expect(page).to have_content '無効なリンクです。リンク発行者に再発行をお願いしてください'
+            end
+          end
+          context '正しい共有リンクから対局詳細ページへアクセスした場合' do
+            it 'アクセス成功' do
+              share_link = create(:share_link, user: user, resource_id: match_group.id, resource_type: 'MatchGroup')
+              visit match_path(match, tk: share_link.token, resource_type: 'MatchGroup')
+              expect(current_path).to eq match_path(match)
+              expect(page).to have_link('成績表を見る',
+                                        href: match_group_path(match_group, tk: share_link.token, resource_type: share_link.resource_type))
+            end
+          end
+        end
+      end
+    end
+
+    describe '------ ログイン後 ------' do
+      before do
+        login(user, player)
+      end
+      describe 'Matches#index' do
+        context '対局一覧ページへアクセスした場合' do
+          it 'アクセス成功' do
+            # 他プレイヤーが記録し、自分が参加した対局
+            match_group_2 =  create(:match_group, rule: rule)
+            match_2 = create(:match, player: other_player, rule: rule, match_group_id: match_group_2.id)
+            players_2 = players + [other_player]
+            results_2 = players_2.each_with_index.map do |player, index|
+              create(:result, match: match_2, player: player, score: 40000 - (10000 * index), point: points[index], ie: index + 1, rank: index + 1)
+            end
+            # 他プレイヤーが記録し、自分が参加していない対局
+            match_group_3 = create(:match_group, rule: rule)
+            match_3 = create(:match, player: other_player, rule: rule, match_group_id: match_group_3.id)
+            players_3 = [other_player] + other_players + [player]
+            results_3 = players_3.each_with_index.map do |player, index|
+              create(:result, match: match_3, player: player, score: 40000 - (10000 * index), point: points[index], ie: index + 1, rank: index + 1)
+            end
+            visit matches_path
+            expect(current_path).to eq matches_path
+            expect(page).to have_content '対局一覧'
+            expect(page).to have_css('.matches-list', count: 2)
+          end
+        end
+      end
+      describe 'Matches#show' do
+        context '対局詳細ページへアクセスした場合' do
+          it 'アクセス成功' do
+            visit match_path(match)
+            expect(current_path).to eq match_path(match)
+            expect(page).to have_content '対局成績'
+          end
+        end
+        context '対局詳細ページ(自分が含まれない対局)へアクセスした場合' do
+          it 'アクセス失敗' do
+            visit match_path(100000)
+            expect(current_path).to eq root_path
+            expect(page).to have_content 'アクセス権限がありません'
+          end
+        end
+      end
+      describe 'Matches#new' do
+        context '対局登録ページへアクセスした場合' do
+          it 'アクセス成功' do
+            # == プレイヤー選択 ==
+            visit new_player_path(play_type: 4)
+            find('li', text: players[0].name).click
+            find('li', text: players[1].name).click
+            find('li', text: players[2].name).click
+            find('#create_btn', visible: true).click # プレイヤー作成ボタンをクリック
+            # == 対局登録 ==
+            visit new_match_path
+            expect(current_path).to eq new_match_path
+            expect(page).to have_content '対局成績登録'
+            expect(page).to have_content '残得点：100000'
+            expect(page).to have_content '残得点が0ではありません'
+          end
+        end
+      end
+      describe 'Matches#edit' do
+        context '対局編集ページへアクセスした場合' do
+          it 'アクセス成功' do
+            visit edit_match_path(match)
+            find('.js-rule-dropdown', visible: true).click # ルール詳細ボタンをクリック
+            expect(current_path).to eq edit_match_path(match)
+            expect(page).to have_content '対局成績編集'
+            expect(page).to have_select('match_rule_id', selected: match.rule.name)
+            expect(page).to have_css('.js-rule-details', count: 1)
+            expect(page).to have_content "#{match.rule.mochi}点持ち / #{match.rule.kaeshi}点返し"
+            expect(page).to have_content "ウマ (#{match.rule.uma_one},#{match.rule.uma_two},#{match.rule.uma_three},#{match.rule.uma_four})"
+            expect(page).to have_content "点数計算 : #{Rule.get_value_score_decimal_point_calc(match.rule.score_decimal_point_calc)}"
+            expect(page).to have_content "チップ : #{Rule.get_value_is_chip(match.rule.is_chip)}"
+            expect(page).to have_field('match_match_on', with: match.match_on)
+            expect(page).to have_content match.results.first.player.name
+            expect(page).to have_field('match_results_attributes_0_score', with: match.results.first.score / 100)
+            expect(page).to have_field('match_results_attributes_0_point', with: match.results.first.point)
+            expect(page).to have_content match.results.first.ie
+            expect(page).to have_content match.results.second.player.name
+            expect(page).to have_field('match_results_attributes_1_score', with: match.results.second.score / 100)
+            expect(page).to have_field('match_results_attributes_1_point', with: match.results.second.point)
+            expect(page).to have_content match.results.second.ie
+            expect(page).to have_content match.results.third.player.name
+            expect(page).to have_field('match_results_attributes_2_score', with: match.results.third.score / 100)
+            expect(page).to have_field('match_results_attributes_2_point', with: match.results.third.point)
+            expect(page).to have_content match.results.third.ie
+            expect(page).to have_content match.results.fourth.player.name
+            expect(page).to have_field('match_results_attributes_3_score', with: match.results.fourth.score / 100)
+            expect(page).to have_field('match_results_attributes_3_point', with: match.results.fourth.point)
+            expect(page).to have_content match.results.fourth.ie
+            expect(page).to have_content "残得点：0"
+            expect(page).to have_no_content "残得点が0ではありません"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/matches_spec.rb
+++ b/spec/system/matches_spec.rb
@@ -166,19 +166,19 @@ RSpec.describe Match, type: :system do
             expect(page).to have_content match.results.first.player.name
             expect(page).to have_field('match_results_attributes_0_score', with: match.results.first.score / 100)
             expect(page).to have_field('match_results_attributes_0_point', with: match.results.first.point)
-            expect(page).to have_content match.results.first.ie
+            expect(page).to have_select('match_results_attributes_0_ie', selected: '東')
             expect(page).to have_content match.results.second.player.name
             expect(page).to have_field('match_results_attributes_1_score', with: match.results.second.score / 100)
             expect(page).to have_field('match_results_attributes_1_point', with: match.results.second.point)
-            expect(page).to have_content match.results.second.ie
+            expect(page).to have_select('match_results_attributes_1_ie', selected: '南')
             expect(page).to have_content match.results.third.player.name
             expect(page).to have_field('match_results_attributes_2_score', with: match.results.third.score / 100)
             expect(page).to have_field('match_results_attributes_2_point', with: match.results.third.point)
-            expect(page).to have_content match.results.third.ie
+            expect(page).to have_select('match_results_attributes_2_ie', selected: '西')
             expect(page).to have_content match.results.fourth.player.name
             expect(page).to have_field('match_results_attributes_3_score', with: match.results.fourth.score / 100)
             expect(page).to have_field('match_results_attributes_3_point', with: match.results.fourth.point)
-            expect(page).to have_content match.results.fourth.ie
+            expect(page).to have_select('match_results_attributes_3_ie', selected: '北')
             expect(page).to have_content "残得点：0"
             expect(page).to have_no_content "残得点が0ではありません"
           end

--- a/spec/system/players_spec.rb
+++ b/spec/system/players_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Player, type: :system do
+  let(:user) { create(:user) }
+  let(:current_p) { create(:player, user: user) }
+  let(:players) { create_list(:player, 3, user: nil) }
+  let(:rule) { create(:rule, player: current_p) }
+  let(:match_group) { create(:match_group, rule: rule) }
+  let(:match) { create(:match, player: current_p, rule: rule, match_group_id: match_group.id) }
+  let(:points) { [50, 10, -20, -40] }
+  let!(:results) do
+    players_1 = players + [current_p]
+    players_1.each_with_index.map do |p, index|
+      create(:result, match: match, player: p, score: 40000 - (10000 * index), point: points[index], ie: index + 1, rank: index + 1)
+    end
+  end
+
+
+  describe '● ACCESS' do
+    describe '------ ログイン前 -------' do
+
+    end
+
+    describe '------ ログイン後 -------' do
+
+    end
+  end
+
+  describe '● OPERATION' do
+    before do
+      login(user, current_p)
+    end
+    describe '------ ルール登録済み -------' do
+      context 'プレイヤーを四人選択してプレイヤー決定ボタンを押した場合' do
+        it '対局登録ページへ遷移し、選択されたプレイヤーがフォームに表示されている' do
+          visit new_player_path(play_type: 4)
+          find('li', text: players[0].name).click
+          find('li', text: players[1].name).click
+          find('li', text: players[2].name).click
+          find('#create_btn', visible: true).click # プレイヤー作成ボタンをクリック
+          expect(current_path).to eq new_match_path
+          expect(page).to have_content players[0].name
+          expect(page).to have_content players[1].name
+          expect(page).to have_content players[2].name
+          expect(page).to have_content current_p.name
+          expect(page).to have_content "残得点：100000"
+          expect(page).to have_content "残得点が0ではありません"
+        end
+      end
+    end
+    describe '------ ルール未登録 -------' do
+
+    end
+  end
+end


### PR DESCRIPTION
## 動作確認

<!-- PCで動かした場合の動作確認を動画で貼る or 見た目のみの作成で機能が必要ない場合は画像でOK -->
**PCの動作確認動画**

## やったこと
<!-- 実装した内容を書く-->
- pr_0222
    - セッションの保存期限を14日に設定
    - リーグ記録権限を”リーグ主催者のみ”から”リーグ主催者またはユーザー登録しているリーグプレイヤー”に変更
    - match,laegueのsystemspec一部実装

## 実装のリンク
<!-- ガントチャートのタスク対象のセルのリンクを貼る -->

## 備考

<!-- なければ、書かなくても良い。相談事項があれば、ここに書く。-->