### PR TITLE
Pr 0321 2

### DIFF
--- a/app/controllers/match_groups/switches_controller.rb
+++ b/app/controllers/match_groups/switches_controller.rb
@@ -9,6 +9,7 @@ module MatchGroups
       mg_ids = Match.where(id: match_ids).or(Match.where(player_id: current_player.id)).distinct.pluck(:match_group_id)
       play_type = params[:play_type] || 4 # デフォルトは四麻
       @match_groups = MatchGroup.includes(:matches).where(id: mg_ids, play_type: play_type).desc
+      @match_groups = @match_groups.sort_by { |mg| mg.matches.last.match_on }.reverse # 対局日の降順
       @first_match_results_p_ids = @match_groups.map { |mg| mg.matches.first.results.pluck(:player_id) }
       @first_match_recorded_player_ids = @match_groups.map { |mg| mg.matches.first.player_id }
       respond_to(&:js)

--- a/app/controllers/match_groups_controller.rb
+++ b/app/controllers/match_groups_controller.rb
@@ -7,9 +7,10 @@ class MatchGroupsController < ApplicationController
   # 記録したor記録された成績表一覧を表示する
   # match_groups/switchesコントローラのindexアクションと同じ処理を記載しないとエラーになるため注意
   def index
-    match_ids = Result.match_ids(current_player.id)
-    mg_ids = Match.where(id: match_ids).or(Match.where(player_id: current_player.id)).distinct.pluck(:match_group_id)
+    match_ids = Result.match_ids(current_player.id) # プレイヤーが参加したすべてのmatch_idを配列で格納
+    mg_ids = Match.where(id: match_ids).or(Match.where(player_id: current_player.id)).distinct.pluck(:match_group_id) # プレイヤーが参加したすべてのmatch_group_idを配列で格納
     @match_groups = MatchGroup.includes(:matches).where(id: mg_ids, play_type: 4).desc # デフォルトは四麻
+    @match_groups = @match_groups.sort_by { |mg| mg.matches.last.match_on }.reverse # 対局日の降順
     @first_match_results_p_ids = @match_groups.map { |mg| mg.matches.first.results.pluck(:player_id) }
     @first_match_recorded_player_ids = @match_groups.map { |mg| mg.matches.first.player_id }
   end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -6,6 +6,11 @@ class PlayersController < ApplicationController
 
   def index
     @created_players = current_player.created_players
+    # 前のページがnew_player_pathであれば変数にpathを格納する
+    if request.referer.include?(new_player_path)
+      @prefer_path_new = request.referer
+    end
+
   end
 
   def show

--- a/app/views/players/_form.html.haml
+++ b/app/views/players/_form.html.haml
@@ -48,7 +48,10 @@
             %li.players_list-item
               .p_name #{p[1]}
               .p_id{style: "display: none"}= p[0]
-
+        .text-center.mb-2
+          = link_to players_path, class: "text-center m-auto d-inline-block fs-sm" do
+            %span プレイヤーを編集する
+            %i.fa-regular.fa-pen-to-square
     .create_players
       .d-flex.align-items-center.mb-1
         %i.bx.bxs-down-arrow.text-green

--- a/app/views/players/index.html.haml
+++ b/app/views/players/index.html.haml
@@ -34,3 +34,8 @@
                   .btn-text
                     %i.fa-solid.fa-user-plus
                     %span 招待
+        - if @prefer_path_new
+          = link_to @prefer_path_new, class: "text-main fs-sm px-1 py-1 m-auto", data: {"turbolinks" => false} do
+            .btn-text
+              %i.fa-solid.fa-arrow-left
+              %span プレイヤー選択に戻る


### PR DESCRIPTION
## 動作確認

<!-- PCで動かした場合の動作確認を動画で貼る or 見た目のみの作成で機能が必要ない場合は画像でOK -->
**PCの動作確認動画**

## やったこと
<!-- 実装した内容を書く-->
- pr_0321_2
    - リーグ成績グラフを対局日付順で表示されるよう修正
    - 成績表一覧表示を対局日付降順で表示するように修正
    - 成績表一覧で、記録者マークの説明を出す
    - プレイヤー選択画面にプレイヤー編集リンクを追加

## 実装のリンク
<!-- ガントチャートのタスク対象のセルのリンクを貼る -->

## 備考

<!-- なければ、書かなくても良い。相談事項があれば、ここに書く。-->